### PR TITLE
In `parse_object` with `extras`; non-unique parents are OK if an exact match is found first

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ dependencies = [
 name = "dycw-utilities"
 readme = "README.md"
 requires-python = ">= 3.12"
-version = "0.112.4"
+version = "0.112.5"
 
 [project.optional-dependencies]
 test = [
@@ -336,7 +336,7 @@ zzz-test-zoneinfo = [
 # bump-my-version
 [tool.bumpversion]
 allow_dirty = true
-current_version = "0.112.4"
+current_version = "0.112.5"
 
 [[tool.bumpversion.files]]
 filename = "src/utilities/__init__.py"

--- a/src/tests/test_dataclasses.py
+++ b/src/tests/test_dataclasses.py
@@ -27,6 +27,7 @@ from tests.test_typing_funcs.with_future import (
     DataClassFutureNestedOuterFirstOuter,
     DataClassFutureNone,
     DataClassFutureNoneDefault,
+    DataClassFutureNumber,
     DataClassFutureTypeLiteral,
     DataClassFutureTypeLiteralNullable,
     TrueOrFalseFutureLit,
@@ -39,9 +40,10 @@ from utilities.dataclasses import (
     StrMappingToFieldMappingError,
     YieldFieldsError,
     _parse_dataclass_split_key_value_pairs,
-    _ParseDataClassParseValueError,
     _ParseDataClassSplitKeyValuePairsDuplicateKeysError,
     _ParseDataClassSplitKeyValuePairsSplitError,
+    _ParseDataClassTextExtraNonUniqueError,
+    _ParseDataClassTextParseError,
     _YieldFieldsClass,
     _YieldFieldsInstance,
     dataclass_repr,
@@ -482,12 +484,26 @@ class TestSerializeAndParseDataClass:
         ):
             _ = parse_dataclass("a=1,b=22a,b=22b,c=3", DataClassFutureInt)
 
-    def test_error_parse_value(self) -> None:
+    def test_error_text_parse(self) -> None:
         with raises(
-            _ParseDataClassParseValueError,
-            match="Unable to construct 'DataClassFutureInt'; unable to parse field 'int_' of type <class 'int'>; got 'invalid'",
+            _ParseDataClassTextParseError,
+            match="Unable to construct 'DataClassFutureInt' since the field 'int_' could not be parsed; got 'invalid'",
         ):
             _ = parse_dataclass("int_=invalid", DataClassFutureInt)
+
+    def test_error_text_extra_non_unique(self) -> None:
+        with raises(
+            _ParseDataClassTextExtraNonUniqueError,
+            match="Unable to construct 'DataClassFutureInt' since the field 'int_' could not be parsed; got 'invalid'",
+        ):
+            _ = parse_dataclass(
+                "number=0",
+                DataClassFutureNumber,
+                extra_parsers={
+                    int: lambda text: int(text),
+                    float: lambda text: float(text),
+                },
+            )
 
 
 class TestStrMappingToFieldMapping:

--- a/src/tests/test_dataclasses.py
+++ b/src/tests/test_dataclasses.py
@@ -486,14 +486,14 @@ class TestSerializeAndParseDataClass:
     def test_error_text_parse(self) -> None:
         with raises(
             _ParseDataClassTextParseError,
-            match="Unable to construct 'DataClassFutureInt' since the field 'int_' could not be parsed; got 'invalid'",
+            match="Unable to construct 'DataClassFutureInt' since the field 'int_' of type <class 'int'> could not be parsed; got 'invalid'",
         ):
             _ = parse_dataclass("int_=invalid", DataClassFutureInt)
 
     def test_error_text_extra_non_unique(self) -> None:
         with raises(
             _ParseDataClassTextExtraNonUniqueError,
-            match="Unable to construct 'DataClassFutureInt' since the field 'int_' must contain exactly one parent class in `extra`; got <class 'int'>, <class 'int'> and perhaps more",
+            match="Unable to construct 'DataClassFutureInt' since the field 'int_' of type <class 'int'> must contain exactly one parent class in `extra`; got <class 'int'>, <class 'int'> and perhaps more",
         ):
             _ = parse_dataclass(
                 "int_=0",

--- a/src/tests/test_dataclasses.py
+++ b/src/tests/test_dataclasses.py
@@ -27,7 +27,6 @@ from tests.test_typing_funcs.with_future import (
     DataClassFutureNestedOuterFirstOuter,
     DataClassFutureNone,
     DataClassFutureNoneDefault,
-    DataClassFutureNumber,
     DataClassFutureTypeLiteral,
     DataClassFutureTypeLiteralNullable,
     TrueOrFalseFutureLit,
@@ -497,12 +496,9 @@ class TestSerializeAndParseDataClass:
             match="Unable to construct 'DataClassFutureInt' since the field 'int_' could not be parsed; got 'invalid'",
         ):
             _ = parse_dataclass(
-                "number=0",
-                DataClassFutureNumber,
-                extra_parsers={
-                    int: lambda text: int(text),
-                    float: lambda text: float(text),
-                },
+                "int_=0",
+                DataClassFutureInt,
+                extra_parsers={int | str: lambda text: int(text), int | float: int},
             )
 
 

--- a/src/tests/test_dataclasses.py
+++ b/src/tests/test_dataclasses.py
@@ -493,12 +493,12 @@ class TestSerializeAndParseDataClass:
     def test_error_text_extra_non_unique(self) -> None:
         with raises(
             _ParseDataClassTextExtraNonUniqueError,
-            match="Unable to construct 'DataClassFutureInt' since the field 'int_' could not be parsed; got 'invalid'",
+            match="Unable to construct 'DataClassFutureInt' since the field 'int_' must contain exactly one parent class in `extra`; got <class 'int'>, <class 'int'> and perhaps more",
         ):
             _ = parse_dataclass(
                 "int_=0",
                 DataClassFutureInt,
-                extra_parsers={int | str: lambda text: int(text), int | float: int},
+                extra_parsers={int | str: int, int | float: int},
             )
 
 

--- a/src/tests/test_parse.py
+++ b/src/tests/test_parse.py
@@ -58,11 +58,6 @@ from utilities.text import parse_bool
 from utilities.types import Duration, Number
 from utilities.version import Version
 
-type Rolling = tuple[Literal["SMA"], int]
-type Rolling2 = Rolling | tuple[Literal["EMA"], int]
-type Rolling3 = Rolling | tuple[Literal["EMA"], int]
-type Number2 = int | float
-
 
 class TestSerializeAndParseObject:
     @given(bool_=booleans())

--- a/src/tests/test_typing.py
+++ b/src/tests/test_typing.py
@@ -167,14 +167,14 @@ class TestGetTypeClasses:
     def test_error_type(self) -> None:
         with raises(
             _GetTypeClassesTypeError,
-            match="Object must be a type, tuple or Union type; got None",
+            match="Object must be a type, tuple or Union type; got None of type <class 'NoneType'>",
         ):
             _ = get_type_classes(None)
 
     def test_error_tuple(self) -> None:
         with raises(
             _GetTypeClassesTupleError,
-            match="Tuple must contain types, tuples or Union types only; got None",
+            match="Tuple must contain types, tuples or Union types only; got None of type <class 'NoneType'>",
         ):
             _ = get_type_classes((None,))
 
@@ -416,14 +416,14 @@ class TestGetUnionTypeClasses:
     def test_error_union_type(self) -> None:
         with raises(
             _GetUnionTypeClassesUnionTypeError,
-            match="Object must be a Union type; got None",
+            match="Object must be a Union type; got None of type <class 'NoneType'>",
         ):
             _ = get_union_type_classes(None)
 
-    def test_error_interal_type(self) -> None:
+    def test_error_internal_type(self) -> None:
         with raises(
             _GetUnionTypeClassesInternalTypeError,
-            match=r"Union type must contain types only; got typing\.Literal\[True\]",
+            match=r"Union type must contain types only; got typing\.Literal\[True\] of type <class 'typing\._LiteralGenericAlias'>",
         ):
             _ = get_union_type_classes(Literal[True] | None)
 
@@ -586,7 +586,8 @@ class TestIsInstanceGen:
 
     def test_error(self) -> None:
         with raises(
-            IsInstanceGenError, match=r"Invalid arguments; got None and typing\.Final"
+            IsInstanceGenError,
+            match=r"Invalid arguments; got None of type <class 'NoneType'> and typing\.Final of type <class 'typing\._SpecialForm'>",
         ):
             _ = is_instance_gen(None, Final)
 
@@ -639,6 +640,9 @@ class TestIsSubclassGen:
             (bool, bool | None, True),
             (bool | None, bool, False),
             (bool | None, bool | None, True),
+            (Number, int, False),
+            (Number, float, False),
+            (Number, Number, True),
             # literals
             (Literal[1, 2], Literal[1, 2, 3], True),
             (Literal[1, 2, 3], Literal[1, 2, 3], True),
@@ -684,5 +688,8 @@ class TestIsSubclassGen:
         assert is_subclass_gen(MyInt, MyInt)
 
     def test_error(self) -> None:
-        with raises(IsSubclassGenError, match="Argument must be a class; got None"):
+        with raises(
+            IsSubclassGenError,
+            match="Argument must be a class; got None of type <class 'NoneType'>",
+        ):
             _ = is_subclass_gen(None, NoneType)

--- a/src/tests/test_typing_funcs/with_future.py
+++ b/src/tests/test_typing_funcs/with_future.py
@@ -154,6 +154,11 @@ class DataClassFutureNoneDefault:
 
 
 @dataclass(order=True, unsafe_hash=True, kw_only=True)
+class DataClassFutureNumber:
+    number: Number
+
+
+@dataclass(order=True, unsafe_hash=True, kw_only=True)
 class DataClassFuturePath:
     path: Path
 

--- a/src/tests/test_typing_funcs/with_future.py
+++ b/src/tests/test_typing_funcs/with_future.py
@@ -88,22 +88,6 @@ class DataClassFutureIntOneAndTwo:
 
 
 @dataclass(order=True, unsafe_hash=True, kw_only=True)
-class DataClassFutureIntParentFirst:
-    int1: int
-
-
-@dataclass(order=True, unsafe_hash=True, kw_only=True)
-class DataClassFutureIntParentSecond:
-    int2: int
-
-
-@dataclass(order=True, unsafe_hash=True, kw_only=True)
-class DataClassFutureIntChild(
-    DataClassFutureIntParentFirst, DataClassFutureIntParentSecond
-): ...
-
-
-@dataclass(order=True, unsafe_hash=True, kw_only=True)
 class DataClassFutureListInts:
     ints: list[int]
 
@@ -151,11 +135,6 @@ class DataClassFutureNone:
 @dataclass(order=True, unsafe_hash=True, kw_only=True)
 class DataClassFutureNoneDefault:
     none: None = None
-
-
-@dataclass(order=True, unsafe_hash=True, kw_only=True)
-class DataClassFutureNumber:
-    number: Number
 
 
 @dataclass(order=True, unsafe_hash=True, kw_only=True)

--- a/src/utilities/__init__.py
+++ b/src/utilities/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.112.4"
+__version__ = "0.112.5"

--- a/src/utilities/dataclasses.py
+++ b/src/utilities/dataclasses.py
@@ -611,7 +611,7 @@ class _ParseDataClassTextParseError(ParseDataClassError[TDataclass]):
 
     @override
     def __str__(self) -> str:
-        return f"Unable to construct {get_class_name(self.cls)!r} since the field {self.field.name!r} could not be parsed; got {self.text!r}"
+        return f"Unable to construct {get_class_name(self.cls)!r} since the field {self.field.name!r} of type {self.field.type_!r} could not be parsed; got {self.text!r}"
 
 
 @dataclass(kw_only=True, slots=True)
@@ -622,7 +622,7 @@ class _ParseDataClassTextExtraNonUniqueError(ParseDataClassError[TDataclass]):
 
     @override
     def __str__(self) -> str:
-        return f"Unable to construct {get_class_name(self.cls)!r} since the field {self.field.name!r} must contain exactly one parent class in `extra`; got {self.first!r}, {self.second!r} and perhaps more"
+        return f"Unable to construct {get_class_name(self.cls)!r} since the field {self.field.name!r} of type {self.field.type_!r} must contain exactly one parent class in `extra`; got {self.first!r}, {self.second!r} and perhaps more"
 
 
 ##

--- a/src/utilities/dataclasses.py
+++ b/src/utilities/dataclasses.py
@@ -22,7 +22,12 @@ from utilities.functions import (
 )
 from utilities.iterables import OneStrEmptyError, OneStrNonUniqueError, one_str
 from utilities.operator import is_equal
-from utilities.parse import ParseObjectError, parse_object, serialize_object
+from utilities.parse import (
+    _ParseObjectExtraNonUniqueError,
+    _ParseObjectParseError,
+    parse_object,
+    serialize_object,
+)
 from utilities.re import ExtractGroupError, extract_group
 from utilities.sentinel import Sentinel, sentinel
 from utilities.text import (
@@ -570,8 +575,12 @@ def _parse_dataclass_parse_text(
             case_sensitive=case_sensitive,
             extra=extra,
         )
-    except ParseObjectError:
-        raise _ParseDataClassParseValueError(cls=cls, field=field, text=text) from None
+    except _ParseObjectParseError:
+        raise _ParseDataClassTextParseError(cls=cls, field=field, text=text) from None
+    except _ParseObjectExtraNonUniqueError as error:
+        raise _ParseDataClassTextExtraNonUniqueError(
+            cls=cls, field=field, text=text, first=error.first, second=error.second
+        ) from None
 
 
 @dataclass(kw_only=True, slots=True)
@@ -597,12 +606,23 @@ class _ParseDataClassSplitKeyValuePairsDuplicateKeysError(ParseDataClassError):
 
 
 @dataclass(kw_only=True, slots=True)
-class _ParseDataClassParseValueError(ParseDataClassError[TDataclass]):
+class _ParseDataClassTextParseError(ParseDataClassError[TDataclass]):
     field: _YieldFieldsClass[Any]
 
     @override
     def __str__(self) -> str:
-        return f"Unable to construct {get_class_name(self.cls)!r}; unable to parse field {self.field.name!r} of type {self.field.type_!r}; got {self.text!r}"
+        return f"Unable to construct {get_class_name(self.cls)!r} since the field {self.field.name!r} could not be parsed; got {self.text!r}"
+
+
+@dataclass(kw_only=True, slots=True)
+class _ParseDataClassTextExtraNonUniqueError(ParseDataClassError[TDataclass]):
+    field: _YieldFieldsClass[Any]
+    first: type[Any]
+    second: type[Any]
+
+    @override
+    def __str__(self) -> str:
+        return f"Unable to construct {get_class_name(self.cls)!r} since the field {self.field.name!r} must contain exactly one parent class in `extra`; got {self.first!r}, {self.second!r} and perhaps more"
 
 
 ##

--- a/src/utilities/parse.py
+++ b/src/utilities/parse.py
@@ -610,7 +610,7 @@ class _SerializeObjectExtraNonUniqueError(SerializeObjectError):
 
     @override
     def __str__(self) -> str:
-        return f"Unable to serialize object {self.obj!r} since `extra` must contain exactly one parent class; got {self.first!r}, {self.second!r} and perhaps more"
+        return f"Unable to serialize object {self.obj!r} of type {type(self.obj)!r} since `extra` must contain exactly one parent class; got {self.first!r}, {self.second!r} and perhaps more"
 
 
 __all__ = ["parse_object", "serialize_object"]

--- a/src/utilities/parse.py
+++ b/src/utilities/parse.py
@@ -283,17 +283,19 @@ def _parse_object_dict_type(
 
 def _parse_object_extra(cls: Any, text: str, extra: ParseObjectExtra, /) -> Any:
     try:
-        parser = one(
-            p for c, p in extra.items() if (cls is c) or is_subclass_gen(cls, c)
-        )
-    except (OneEmptyError, TypeError):
-        raise _ParseObjectParseError(type_=cls, text=text) from None
-    except OneNonUniqueError as error:
-        raise _ParseObjectExtraNonUniqueError(
-            type_=cls, text=text, first=error.first, second=error.second
-        ) from None
-    else:
-        return parser(text)
+        parser = extra[cls]
+    except KeyError:
+        try:
+            parser = one(
+                p for c, p in extra.items() if (cls is c) or is_subclass_gen(cls, c)
+            )
+        except (OneEmptyError, TypeError):
+            raise _ParseObjectParseError(type_=cls, text=text) from None
+        except OneNonUniqueError as error:
+            raise _ParseObjectExtraNonUniqueError(
+                type_=cls, text=text, first=error.first, second=error.second
+            ) from None
+    return parser(text)
 
 
 def _parse_object_list_type(
@@ -600,7 +602,7 @@ class SerializeObjectError(Exception):
 class _SerializeObjectSerializeError(SerializeObjectError):
     @override
     def __str__(self) -> str:
-        return f"Unable to serialize object {self.obj!r}"
+        return f"Unable to serialize object {self.obj!r} of type {type(self.obj)!r}"
 
 
 @dataclass

--- a/src/utilities/typing.py
+++ b/src/utilities/typing.py
@@ -108,7 +108,7 @@ class GetTypeClassesError(Exception):
 class _GetTypeClassesTypeError(GetTypeClassesError):
     @override
     def __str__(self) -> str:
-        return f"Object must be a type, tuple or Union type; got {self.obj}"
+        return f"Object must be a type, tuple or Union type; got {self.obj!r} of type {type(self.obj)!r}"
 
 
 @dataclass(kw_only=True, slots=True)
@@ -117,7 +117,7 @@ class _GetTypeClassesTupleError(GetTypeClassesError):
 
     @override
     def __str__(self) -> str:
-        return f"Tuple must contain types, tuples or Union types only; got {self.inner}"
+        return f"Tuple must contain types, tuples or Union types only; got {self.inner} of type {type(self.inner)!r}"
 
 
 ##
@@ -177,7 +177,9 @@ class GetUnionTypeClassesError(Exception):
 class _GetUnionTypeClassesUnionTypeError(GetUnionTypeClassesError):
     @override
     def __str__(self) -> str:
-        return f"Object must be a Union type; got {self.obj}"
+        return (
+            f"Object must be a Union type; got {self.obj!r} of type {type(self.obj)!r}"
+        )
 
 
 @dataclass(kw_only=True, slots=True)
@@ -186,7 +188,7 @@ class _GetUnionTypeClassesInternalTypeError(GetUnionTypeClassesError):
 
     @override
     def __str__(self) -> str:
-        return f"Union type must contain types only; got {self.inner}"
+        return f"Union type must contain types only; got {self.inner} of type {type(self.inner)!r}"
 
 
 ##
@@ -272,7 +274,7 @@ class IsInstanceGenError(Exception):
 
     @override
     def __str__(self) -> str:
-        return f"Invalid arguments; got {self.obj!r} and {self.type_!r}"
+        return f"Invalid arguments; got {self.obj!r} of type {type(self.obj)!r} and {self.type_!r} of type {type(self.type_)!r}"
 
 
 ##
@@ -432,7 +434,7 @@ class IsSubclassGenError(Exception):
 
     @override
     def __str__(self) -> str:
-        return f"Argument must be a class; got {self.cls!r}"
+        return f"Argument must be a class; got {self.cls!r} of type {type(self.cls)!r}"
 
 
 ##

--- a/uv.lock
+++ b/uv.lock
@@ -753,7 +753,7 @@ wheels = [
 
 [[package]]
 name = "dycw-utilities"
-version = "0.112.4"
+version = "0.112.5"
 source = { editable = "." }
 dependencies = [
     { name = "typing-extensions" },


### PR DESCRIPTION
- **save**
- **Saved at 2025-04-28 17:09:04 (Mon)**
- **Saved at 2025-04-28 17:15:38 (Mon)**
- **Saved at 2025-04-28 17:24:19 (Mon)**
