### PR TITLE
Make `asyncio` tests cleaner by suppressing `TimeoutError` after `run_looper`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ dependencies = [
 name = "dycw-utilities"
 readme = "README.md"
 requires-python = ">= 3.12"
-version = "0.126.13"
+version = "0.127.0"
 
 [project.optional-dependencies]
 test = [
@@ -334,7 +334,7 @@ zzz-test-zoneinfo = [
 # bump-my-version
 [tool.bumpversion]
 allow_dirty = true
-current_version = "0.126.13"
+current_version = "0.127.0"
 
 [[tool.bumpversion.files]]
 filename = "src/utilities/__init__.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ dependencies = [
 name = "dycw-utilities"
 readme = "README.md"
 requires-python = ">= 3.12"
-version = "0.126.12"
+version = "0.126.13"
 
 [project.optional-dependencies]
 test = [
@@ -334,7 +334,7 @@ zzz-test-zoneinfo = [
 # bump-my-version
 [tool.bumpversion]
 allow_dirty = true
-current_version = "0.126.12"
+current_version = "0.126.13"
 
 [[tool.bumpversion.files]]
 filename = "src/utilities/__init__.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -375,6 +375,7 @@ data_file = ".coverage/data"
 omit = ["src/utilities/streamlit.py"]
 parallel = true
 plugins = ["coverage_conditional_plugin"]
+source = ["src/utilities"]
 
 # hatch
 [tool.hatch]

--- a/src/tests/test_asyncio.py
+++ b/src/tests/test_asyncio.py
@@ -1363,7 +1363,7 @@ class TestLooper:
         with Timer() as timer:
             async with looper:
                 await looper
-        assert timer == approx(1.0, rel=_REL)
+        assert float(timer) == approx(1.0, rel=_REL)
         self._assert_stats_full(looper, stops=1)
 
     def test_with_auto_start(self) -> None:

--- a/src/tests/test_asyncio.py
+++ b/src/tests/test_asyncio.py
@@ -42,7 +42,6 @@ from utilities.asyncio import (
     InfiniteLooper,
     InfiniteQueueLooper,
     Looper,
-    LooperTimeoutError,
     UniquePriorityQueue,
     UniqueQueue,
     _InfiniteLooperDefaultEventError,
@@ -1362,7 +1361,7 @@ class TestLooper:
     async def test_timeout(self) -> None:
         looper = CountingLooper(timeout=1.0)
         async with looper:
-            with raises(LooperTimeoutError, match="Timeout"):
+            with raises(TimeoutError, match="Timeout"):
                 await looper
         self._assert_stats_full(looper, stops=1)
 

--- a/src/tests/test_asyncio.py
+++ b/src/tests/test_asyncio.py
@@ -21,7 +21,7 @@ from hypothesis.strategies import (
     permutations,
     sampled_from,
 )
-from pytest import LogCaptureFixture, mark, param, raises
+from pytest import LogCaptureFixture, approx, mark, param, raises
 
 from tests.test_asyncio_classes.loopers import (
     _REL,
@@ -1360,9 +1360,10 @@ class TestLooper:
 
     async def test_timeout(self) -> None:
         looper = CountingLooper(timeout=1.0)
-        async with looper:
-            with raises(TimeoutError, match="Timeout"):
+        with Timer() as timer:
+            async with looper:
                 await looper
+        assert timer == approx(1.0, rel=_REL)
         self._assert_stats_full(looper, stops=1)
 
     def test_with_auto_start(self) -> None:

--- a/src/tests/test_sqlalchemy.py
+++ b/src/tests/test_sqlalchemy.py
@@ -170,7 +170,7 @@ class TestCheckEngine:
 
 class TestColumnwiseMinMax:
     @given(data=data(), values=sets(pairs(integers(0, 10) | none()), min_size=1))
-    @settings_with_reduced_examples(phases={Phase.generate})
+    @settings(max_examples=1, phases={Phase.generate})
     async def test_main(
         self, *, data: DataObject, values: set[tuple[int | None, int | None]]
     ) -> None:

--- a/src/utilities/__init__.py
+++ b/src/utilities/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.126.12"
+__version__ = "0.126.13"

--- a/src/utilities/__init__.py
+++ b/src/utilities/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.126.13"
+__version__ = "0.127.0"

--- a/src/utilities/asyncio.py
+++ b/src/utilities/asyncio.py
@@ -664,15 +664,6 @@ class LooperError(Exception): ...
 
 
 @dataclass(kw_only=True, slots=True)
-class LooperTimeoutError(LooperError):
-    duration: Duration | None = None
-
-    @override
-    def __str__(self) -> str:
-        return "Timeout" if self.duration is None else f"Timeout after {self.duration}"
-
-
-@dataclass(kw_only=True, slots=True)
 class _LooperNoTaskError(LooperError):
     looper: Looper
 
@@ -756,7 +747,7 @@ class Looper(Generic[_T]):
                     _ = await self._stack.enter_async_context(looper)
                 if self.auto_start:
                     _ = self._debug and self._logger.debug("%s: auto-starting...", self)
-                    with suppress(self.timeout_error):
+                    with suppress(TimeoutError):
                         await self._task
             case _ as never:
                 assert_never(never)
@@ -1429,7 +1420,6 @@ __all__ = [
     "InfiniteQueueLooper",
     "Looper",
     "LooperError",
-    "LooperTimeoutError",
     "StreamCommandOutput",
     "UniquePriorityQueue",
     "UniqueQueue",

--- a/src/utilities/redis.py
+++ b/src/utilities/redis.py
@@ -25,13 +25,7 @@ from typing import (
 from redis.asyncio import Redis
 from redis.typing import EncodableT
 
-from utilities.asyncio import (
-    EnhancedQueue,
-    InfiniteQueueLooper,
-    Looper,
-    LooperTimeoutError,
-    timeout_dur,
-)
+from utilities.asyncio import EnhancedQueue, InfiniteQueueLooper, Looper, timeout_dur
 from utilities.contextlib import suppress_super_object_attribute_error
 from utilities.datetime import (
     MILLISECOND,
@@ -702,9 +696,6 @@ class PublishServiceMixin(Generic[_T]):
     publish_service_empty_upon_exit: bool = field(default=False, repr=False)
     publish_service_logger: str | None = field(default=None, repr=False)
     publish_service_timeout: Duration | None = field(default=None, repr=False)
-    publish_service_timeout_error: type[Exception] = field(
-        default=LooperTimeoutError, repr=False
-    )
     publish_service_debug: bool = field(default=False, repr=False)
     _is_pending_restart: Event = field(default_factory=Event, init=False, repr=False)
     # base - publish service
@@ -724,7 +715,6 @@ class PublishServiceMixin(Generic[_T]):
             empty_upon_exit=self.publish_service_empty_upon_exit,
             logger=self.publish_service_logger,
             timeout=self.publish_service_timeout,
-            timeout_error=self.publish_service_timeout_error,
             _debug=self.publish_service_debug,
             # publish service
             redis=self.publish_service_redis,
@@ -986,9 +976,6 @@ class SubscribeServiceMixin(Generic[_T]):
     subscribe_service_empty_upon_exit: bool = field(default=False, repr=False)
     subscribe_service_logger: str | None = field(default=None, repr=False)
     subscribe_service_timeout: Duration | None = field(default=None, repr=False)
-    subscribe_service_timeout_error: type[Exception] = field(
-        default=LooperTimeoutError, repr=False
-    )
     subscribe_service_debug: bool = field(default=False, repr=False)
     # base - looper
     subscribe_service_redis: Redis
@@ -1009,7 +996,6 @@ class SubscribeServiceMixin(Generic[_T]):
             empty_upon_exit=self.subscribe_service_empty_upon_exit,
             logger=self.subscribe_service_logger,
             timeout=self.subscribe_service_timeout,
-            timeout_error=self.subscribe_service_timeout_error,
             _debug=self.subscribe_service_debug,
             # subscribe service
             redis=self.subscribe_service_redis,

--- a/src/utilities/slack_sdk.py
+++ b/src/utilities/slack_sdk.py
@@ -7,12 +7,7 @@ from typing import TYPE_CHECKING, Any, Self, override
 
 from slack_sdk.webhook.async_client import AsyncWebhookClient
 
-from utilities.asyncio import (
-    InfiniteQueueLooper,
-    Looper,
-    LooperTimeoutError,
-    timeout_dur,
-)
+from utilities.asyncio import InfiniteQueueLooper, Looper, timeout_dur
 from utilities.datetime import MINUTE, SECOND, datetime_duration_to_float
 from utilities.functools import cache
 from utilities.math import safe_round
@@ -94,7 +89,6 @@ class SlackHandlerService(Handler, Looper[str]):
         backoff: Duration = SECOND,
         logger: str | None = None,
         timeout: Duration | None = None,
-        timeout_error: type[Exception] = LooperTimeoutError,
         _debug: bool = False,
         level: int = NOTSET,
         sender: Callable[[str, str], Coroutine1[None]] = _send_adapter,
@@ -108,7 +102,6 @@ class SlackHandlerService(Handler, Looper[str]):
             backoff=backoff,
             logger=logger,
             timeout=timeout,
-            timeout_error=timeout_error,
             _debug=_debug,
         )
         Looper.__post_init__(self)
@@ -144,7 +137,6 @@ class SlackHandlerService(Handler, Looper[str]):
         backoff: Duration | Sentinel = sentinel,
         logger: str | None | Sentinel = sentinel,
         timeout: Duration | None | Sentinel = sentinel,
-        timeout_error: type[Exception] | Sentinel = sentinel,
         _debug: bool | Sentinel = sentinel,
         **kwargs: Any,
     ) -> Self:
@@ -157,7 +149,6 @@ class SlackHandlerService(Handler, Looper[str]):
             backoff=backoff,
             logger=logger,
             timeout=timeout,
-            timeout_error=timeout_error,
             _debug=_debug,
             **kwargs,
         )

--- a/src/utilities/sqlalchemy.py
+++ b/src/utilities/sqlalchemy.py
@@ -57,12 +57,7 @@ from sqlalchemy.orm import (
 from sqlalchemy.orm.exc import UnmappedClassError
 from sqlalchemy.pool import NullPool, Pool
 
-from utilities.asyncio import (
-    InfiniteQueueLooper,
-    Looper,
-    LooperTimeoutError,
-    timeout_dur,
-)
+from utilities.asyncio import InfiniteQueueLooper, Looper, timeout_dur
 from utilities.contextlib import suppress_super_object_attribute_error
 from utilities.datetime import SECOND
 from utilities.functions import (
@@ -707,9 +702,6 @@ class UpsertServiceMixin:
     upsert_service_empty_upon_exit: bool = field(default=False, repr=False)
     upsert_service_logger: str | None = field(default=None, repr=False)
     upsert_service_timeout: Duration | None = field(default=None, repr=False)
-    upsert_service_timeout_error: type[Exception] = field(
-        default=LooperTimeoutError, repr=False
-    )
     upsert_service_debug: bool = field(default=False, repr=False)
     # base - upsert service
     upsert_service_database: AsyncEngine
@@ -734,7 +726,6 @@ class UpsertServiceMixin:
             empty_upon_exit=self.upsert_service_empty_upon_exit,
             logger=self.upsert_service_logger,
             timeout=self.upsert_service_timeout,
-            timeout_error=self.upsert_service_timeout_error,
             _debug=self.upsert_service_debug,
             # upsert service
             engine=self.upsert_service_database,

--- a/uv.lock
+++ b/uv.lock
@@ -757,7 +757,7 @@ wheels = [
 
 [[package]]
 name = "dycw-utilities"
-version = "0.126.12"
+version = "0.126.13"
 source = { editable = "." }
 dependencies = [
     { name = "typing-extensions" },

--- a/uv.lock
+++ b/uv.lock
@@ -757,7 +757,7 @@ wheels = [
 
 [[package]]
 name = "dycw-utilities"
-version = "0.126.13"
+version = "0.127.0"
 source = { editable = "." }
 dependencies = [
     { name = "typing-extensions" },


### PR DESCRIPTION
=